### PR TITLE
add pager class when no results

### DIFF
--- a/js/evolugrid.js
+++ b/js/evolugrid.js
@@ -590,7 +590,13 @@
 	    		else {
 	    			$this.append(pager);
 	    		}
-	    		
+
+	    		if (data.count == 0){
+                    pager.addClass('no-results');
+                }else{
+                    pager.removeClass('no-results');
+				}
+
 	    		// Finally, let's enable buttons again:
 		    	if (descriptor.filterFormSubmitButton) {
 		    		$(descriptor.filterFormSubmitButton).attr("disabled", false);


### PR DESCRIPTION
Add 'no-results' class to pager when empty result set ha been returned. This allows styling the pages when no results, for instance hiding it